### PR TITLE
diagnose ARIMA defaults

### DIFF
--- a/train.py
+++ b/train.py
@@ -28,6 +28,14 @@ def main():
     arima_predictions_improved = data.predictions(model_name=arima, order=(1,1,1), lookback=5, preprocessed_data=X_improved)
     arima_rmse_improved = data.error(error_fn=RMSE, predictions=arima_predictions_improved)
     print('ARIMA model RMSE with better preprocessing:', arima_rmse_improved)
+
+
+
+    print('Diagnostics...')
+
+    # Check how often ARIMA defaults to Status Quo
+    arima_is_sq = (arima_predictions_improved==status_quo_predictions_improved).mean()
+    print('ARIMA defaults to Status Quo (%):', arima_is_sq)
     
 
 if __name__ == '__main__':


### PR DESCRIPTION
Looks like ARIMA defaults to Status Quo about 85% of the time.

Output:
```
Predicting 2007 from 1972:2006
Status quo model RMSE with simple preprocessing: 0.054186725997562385
Status quo model RMSE with better preprocessing: 0.02389522670468707
ARIMA model RMSE with simple preprocessing: 0.05320123121701321
ARIMA model RMSE with better preprocessing: 0.02156790159438188
Diagnostics...
ARIMA defaults to Status Quo (%): 0.8521031207598372
```